### PR TITLE
Ajout de la scène MainMenu avec gestion de version

### DIFF
--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  - component: {fileID: 3}
+  m_Layer: 0
+  m_Name: MainMenuController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ab52092ac8cc4913980f1140c0bf53bb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scenes/MainMenu.unity.meta
+++ b/Assets/Scenes/MainMenu.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 526c2192e3734eeb9aaf98dbdf71dfec
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MainMenuController.cs
+++ b/Assets/Scripts/MainMenuController.cs
@@ -1,0 +1,97 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class MainMenuController : MonoBehaviour
+{
+    void Start()
+    {
+        var canvasGO = new GameObject("Canvas");
+        var canvas = canvasGO.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvasGO.AddComponent<CanvasScaler>();
+        canvasGO.AddComponent<GraphicRaycaster>();
+
+        CreateBackground(canvasGO.transform);
+        CreateButtons(canvasGO.transform);
+        CreateVersionFooter(canvasGO.transform);
+    }
+
+    void CreateBackground(Transform parent)
+    {
+        var bgGO = new GameObject("Background");
+        bgGO.transform.SetParent(parent, false);
+        var rect = bgGO.AddComponent<RectTransform>();
+        rect.anchorMin = Vector2.zero;
+        rect.anchorMax = Vector2.one;
+        rect.offsetMin = Vector2.zero;
+        rect.offsetMax = Vector2.zero;
+        var image = bgGO.AddComponent<Image>();
+        image.color = Color.black;
+    }
+
+    void CreateButtons(Transform parent)
+    {
+        CreateButton(parent, "Rejoindre le lobby", new Vector2(0, 40), OnJoinLobby);
+        CreateButton(parent, "Options", new Vector2(0, -10), OnOptions);
+        CreateButton(parent, "Quitter", new Vector2(0, -60), OnQuit);
+    }
+
+    void CreateButton(Transform parent, string label, Vector2 anchoredPos, UnityEngine.Events.UnityAction onClick)
+    {
+        var buttonGO = new GameObject(label);
+        buttonGO.transform.SetParent(parent, false);
+        var rect = buttonGO.AddComponent<RectTransform>();
+        rect.sizeDelta = new Vector2(200, 40);
+        rect.anchoredPosition = anchoredPos;
+
+        var image = buttonGO.AddComponent<Image>();
+        image.color = Color.white;
+
+        var button = buttonGO.AddComponent<Button>();
+        var colors = button.colors;
+        colors.highlightedColor = new Color(0.8f, 0.8f, 0.8f);
+        button.colors = colors;
+        button.onClick.AddListener(onClick);
+
+        var textGO = new GameObject("Text");
+        textGO.transform.SetParent(buttonGO.transform, false);
+        var textRect = textGO.AddComponent<RectTransform>();
+        textRect.anchorMin = Vector2.zero;
+        textRect.anchorMax = Vector2.one;
+        textRect.offsetMin = Vector2.zero;
+        textRect.offsetMax = Vector2.zero;
+        var text = textGO.AddComponent<Text>();
+        text.text = label;
+        text.alignment = TextAnchor.MiddleCenter;
+        text.color = Color.black;
+    }
+
+    void CreateVersionFooter(Transform parent)
+    {
+        var textGO = new GameObject("Version");
+        textGO.transform.SetParent(parent, false);
+        var rect = textGO.AddComponent<RectTransform>();
+        rect.anchorMin = new Vector2(0.5f, 0);
+        rect.anchorMax = new Vector2(0.5f, 0);
+        rect.anchoredPosition = new Vector2(0, 20);
+        var text = textGO.AddComponent<Text>();
+        text.text = VersionInfo.Version;
+        text.alignment = TextAnchor.MiddleCenter;
+        text.color = Color.gray;
+    }
+
+    void OnJoinLobby()
+    {
+        // Logique à définir
+    }
+
+    void OnOptions()
+    {
+        // Fenêtre d'options à implémenter
+    }
+
+    void OnQuit()
+    {
+        Application.Quit();
+    }
+}

--- a/Assets/Scripts/MainMenuController.cs.meta
+++ b/Assets/Scripts/MainMenuController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab52092ac8cc4913980f1140c0bf53bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/VersionInfo.cs
+++ b/Assets/Scripts/VersionInfo.cs
@@ -1,0 +1,7 @@
+namespace BaboonTower
+{
+    public static class VersionInfo
+    {
+        public const string Version = "v1.0.0";
+    }
+}

--- a/Assets/Scripts/VersionInfo.cs.meta
+++ b/Assets/Scripts/VersionInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9bd8b161cc343d5b776c52118457f6a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,8 @@
 - Initialisation du `CHANGELOG.md`.
 - Ajout du Game Design Document `GDD.md`.
 - Génération du squelette de projet Unity (répertoires `Assets`, `ProjectSettings`, `Packages`, `.gitignore`).
+
+## v1.0.0 - 2025-08-06
+- Auteur : IA
+- Ajout de la scène `MainMenu` générant dynamiquement le Canvas, le fond, les boutons et le footer de version.
+- Création des scripts `MainMenuController` et `VersionInfo`.


### PR DESCRIPTION
## Résumé
- création d'une scène `MainMenu` minimaliste reliée au contrôleur
- génération du Canvas, des boutons et du footer de version via `MainMenuController`
- ajout de `VersionInfo` pour centraliser le numéro de version et mise à jour du `CHANGELOG`

## Tests
- `dotnet test` (aucun projet trouvé)


------
https://chatgpt.com/codex/tasks/task_b_68938512baac8322a4b4945addbe3072